### PR TITLE
Several features + improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Google Analytics Custim Widget
+# Google Analytics Custom Widget
 
-With this widget you are a able to add Google Analytics Page Tracking and Event Tracking inside a Mendix application.
+With this widget you are a able to add Google Analytics Page Tracking (for master layout and specific page) and Event Tracking inside a Mendix application.
 
 ## Contributing
 

--- a/src/GoogleAnalytics/MasterPageTracker.xml
+++ b/src/GoogleAnalytics/MasterPageTracker.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<widget id="GoogleAnalytics.widget.PageTracker" needsEntityContext="false" xmlns="http://www.mendix.com/widget/1.0/">
-  <name>PageTracker</name>
+<widget id="GoogleAnalytics.widget.MasterPageTracker" needsEntityContext="false" xmlns="http://www.mendix.com/widget/1.0/">
+  <name>MasterPageTracker</name>
   <description>The page tracker google analytics code.</description>
   <icon>
         iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJ
@@ -19,20 +19,10 @@
         AQA+108un+UF/QAAAABJRU5ErkJggg==
     </icon>
     <properties>
-        <property key="trackUrl" type="string" defaultValue="/">
-            <caption>Url</caption>
-            <category>Behavior</category>
-            <description>Url to track</description>
-        </property>
-        <property key="pageTitle" type="string" defaultValue="">
-            <caption>Title</caption>
-            <category>Behavior</category>
-            <description>Title to track</description>
-        </property>
         <property key="uaTrackCode" type="string" defaultValue="UA-">
             <caption>UA-XXX-XX</caption>
             <category>Behavior</category>
-            <description>The UA-XXX-XX code for including google analytics code inside the webpage. NOTE: You DO NOT have to fill this value if you also use the MasterPageTracker widget</description>
+            <description>The UA-XXX-XX code for including google analytics code inside the webpage.</description>
         </property>
         <property key="trackIt" type="boolean" defaultValue="true">
             <caption>Active</caption>

--- a/src/GoogleAnalytics/PageTracker.xml
+++ b/src/GoogleAnalytics/PageTracker.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<widget id="GoogleAnalytics.widget.PageTracker" needsEntityContext="false" xmlns="http://www.mendix.com/widget/1.0/">
+<widget id="GoogleAnalytics.widget.PageTracker" needsEntityContext="true" xmlns="http://www.mendix.com/widget/1.0/">
   <name>PageTracker</name>
   <description>The page tracker google analytics code.</description>
   <icon>
@@ -19,6 +19,33 @@
         AQA+108un+UF/QAAAABJRU5ErkJggg==
     </icon>
     <properties>
+        <property key="attributeList" type="object" isList="true" required="false">
+            <caption>Attributes</caption>
+            <category>Data source</category>
+            <description></description>
+            <properties>
+                <property key="variableName" type="string" required="true">
+                    <caption>Variable name</caption>
+                    <category>Data source</category>
+                    <description>Identifies the attribute value, this name should be used in 'Display string' property.</description>
+                </property>
+                <property key="attr" type="attribute" allowNonPersistableEntities="true" isPath="optional" pathType="reference">
+                    <caption>Attribute</caption>
+                    <category>Data source</category>
+                    <description>Value of this attribute will be used to replace ${your_Variable_Name}, defined in 'Url' property</description>
+                    <attributeTypes>
+                        <attributeType name="AutoNumber"/>
+                        <attributeType name="String" />
+                        <attributeType name="Enum"/>
+                        <attributeType name="Integer"/>
+                        <attributeType name="Float"/>
+                        <attributeType name="Long"/>
+                        <attributeType name="DateTime"/>
+                        <attributeType name="Currency"/>
+                    </attributeTypes>
+                </property>
+            </properties>
+        </property>
         <property key="trackUrl" type="string" defaultValue="/">
             <caption>Url</caption>
             <category>Behavior</category>

--- a/src/GoogleAnalytics/widget/EventTracker.js
+++ b/src/GoogleAnalytics/widget/EventTracker.js
@@ -76,8 +76,9 @@ define([
 
         _insertGoogleAnalytics: function () {
             this._addGoogle(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
-
-            ga('create', this.uaTrackCode, 'auto');
+            if (typeof window.mxGoogleAnalytics === "undefined") {
+                ga('create', this.uaTrackCode, 'auto');
+            }
         },
 
         _addEvent: function () {

--- a/src/GoogleAnalytics/widget/PageTracker.js
+++ b/src/GoogleAnalytics/widget/PageTracker.js
@@ -2,20 +2,20 @@
 /*global mx, dojo, mxui, define, require, browser, devel, console, document, jQuery, ga, window */
 /*mendix */
 /*
-    GoogleAnalytics
-    ========================
+ GoogleAnalytics
+ ========================
 
-    @file      : GoogleAnalytics.js
-    @version   : 2.0.0
-    @author    : Gerhard Richard Edens
-    @date      : Wed, 20 May 2015 12:17:18 GMT
-    @copyright : Mendix b.v.
-    @license   : Apache 2
+ @file      : PageTracker.js
+ @version   : 2.1.0
+ @author    : Gerhard Richard Edens, Ismail Habib Muhammad
+ @date      : Wed, 2 June 2015
+ @copyright : Mendix b.v.
+ @license   : Apache 2
 
-    Documentation
-    ========================
-    Describe your widget here.
-*/
+ Documentation
+ ========================
+ Describe your widget here.
+ */
 
 // Required module list. Remove unnecessary modules, you can always get them back from the boilerplate.
 define([
@@ -45,7 +45,7 @@ define([
         postCreate: function () {
             console.log(this.id + ".postCreate");
             this._insertGoogleAnalytics();
-            this.connect(this.mxform, "onNavigation", function() {
+            this.connect(this.mxform, "onNavigation", function () {
                 // Track it or not?
                 if (this.trackIt) {
                     this._addPage();
@@ -60,7 +60,7 @@ define([
             callback();
         },
 
-        _addGoogle: function(i, s, o, g, r, a, m) {
+        _addGoogle: function (i, s, o, g, r, a, m) {
             if (typeof ga === "undefined") {
                 i.GoogleAnalyticsObject = r;
                 i[r] = i[r] || function () {
@@ -91,7 +91,7 @@ define([
             if (this.attributeList.length === 0) {
                 callback(s);
             } else {
-                this._replaceTagsRecursive(s, 0, function(str) {
+                this._replaceTagsRecursive(s, 0, function (str) {
                     callback(str);
                 });
             }

--- a/src/GoogleAnalytics/widget/PageTracker.js
+++ b/src/GoogleAnalytics/widget/PageTracker.js
@@ -74,27 +74,23 @@ define([
                 m.parentNode.insertBefore(a, m);
             }
         },
-        _replaceTagsRecursive: function (s, iterator, callback) {
-            var toBeReplacedValue = "${" + this.attributeList[iterator].variableName + "}";
-            this._contextObj.fetch(this.attributeList[iterator].attr, lang.hitch(this, function (value) {
-                    var str = s.replace(toBeReplacedValue, value);
-                    iterator++;
-                    if (iterator < this.attributeList.length) {
-                        lang.hitch(this, this._replaceTagsRecursive(str, iterator, callback));
-                    } else {
-                        lang.hitch(this, callback(str));
-                    }
-                })
-            );
+        _replaceTagsRecursive: function (s, attrs, callback) {
+            var attr = attrs.pop();
+            if (attr === undefined) {
+                lang.hitch(this, callback(s));
+            } else {
+                var toBeReplacedValue = "${" + attr.variableName + "}";
+                this._contextObj.fetch(attr.attr, lang.hitch(this, function (value) {
+                        var str = s.replace(toBeReplacedValue, value);
+                        lang.hitch(this, this._replaceTagsRecursive(str, attrs, callback));
+                    })
+                );
+            }
         },
         _replaceTags: function (s, callback) {
-            if (this.attributeList.length === 0) {
-                callback(s);
-            } else {
-                this._replaceTagsRecursive(s, 0, function (str) {
-                    callback(str);
-                });
-            }
+            this._replaceTagsRecursive(s, this.attributeList.slice(), function (str) {
+                callback(str);
+            });
         },
         _insertGoogleAnalytics: function () {
             this._addGoogle(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
@@ -103,7 +99,6 @@ define([
                 ga('create', this.uaTrackCode, 'auto');
             }
         },
-
         _addPage: function () {
             this._replaceTags(this.trackUrl, lang.hitch(this, function (newTrackUrl) {
                     this._replaceTags(this.pageTitle, function (newPageTitle) {

--- a/src/GoogleAnalytics/widget/PageTracker.js
+++ b/src/GoogleAnalytics/widget/PageTracker.js
@@ -1,5 +1,5 @@
 /*jslint white:true, nomen: true, plusplus: true */
-/*global mx, define, require, browser, devel, console, document, jQuery, ga, window */
+/*global mx, dojo, mxui, define, require, browser, devel, console, document, jQuery, ga, window */
 /*mendix */
 /*
     GoogleAnalytics
@@ -45,15 +45,18 @@ define([
         postCreate: function () {
             console.log(this.id + ".postCreate");
             this._insertGoogleAnalytics();
-            // Track it or not?
-            if (this.trackIt) {
-                this._addPage();
-            }
+            this.connect(this.mxform, "onNavigation", function() {
+                // Track it or not?
+                if (this.trackIt) {
+                    this._addPage();
+                }
+            });
         },
 
         // mxui.widget._WidgetBase.update is called when context is changed or initialized. Implement to re-render and / or fetch data.
         update: function (obj, callback) {
             console.log(this.id + ".update");
+            this._contextObj = obj;
             callback();
         },
 
@@ -71,7 +74,74 @@ define([
                 m.parentNode.insertBefore(a, m);
             }
         },
-        _replaceTags: function(s) {
+        _replaceTags: function (s) {
+            var i;
+            var str = s;
+            for (i = 0; i < this.attributeList.length; i++) {
+                var toBeReplacedValue = "${" + this.attributeList[i].variableName + "}";
+                var replacementValue = this._getObjectAttr(this._contextObj, this.attributeList[i].attr, false);
+                str = str.replace(toBeReplacedValue, replacementValue);
+            }
+            return str;
+        },
+        _getObjectAttr: function (object, attr, renderValue) {
+            if (!object || !attr) {
+                return "";
+            }
+
+            if (attr.indexOf("/") === -1) {
+                if (renderValue) {
+                    return mx.parser && mx.parser.formatAttribute ? mx.parser.formatAttribute(object, attr) : mxui.html.renderValue(object, attr); //mxui.html.rendervalue moved in 5.~7.
+                }
+                return object.getAttribute(attr);
+            }
+            var parts = attr.split("/");
+            if (parts.length === 3) {
+                var child = object.get(parts[0]);
+
+                if (!child) {
+                    return "";
+                }
+
+                //Fine, we have an object
+                if (dojo.isObject(child)) {
+                    child = object.getChild(parts[0]); //Get child only works if child was not a guid but object
+                    return this._getObjectAttr(child, parts[2], renderValue);
+                }
+
+                //Try to retrieve guid in syc
+                else {
+                    //..but, there is a guid...
+                    var tmp = null;
+                    mx.processor.get({
+                        guid: child, noCache: false, callback: function (obj) { //async = false option would be nice!
+                            tmp = obj;
+                        }
+                    });
+                    if (tmp !== null) {//callback was invoked in sync :)
+                        return this._getObjectAttr(tmp, parts[2], renderValue);
+                    }
+
+                    //console && console.warn && console.warn("Commons.getObjectAttr failed to retrieve " + attr );
+                    //This happens if no retrieve schema was used :-(.
+                    return "";
+                }
+            }
+
+            //objects can be returned in X different ways, sometime just a guid, sometimes its an object...
+            if (parts.length === 2) {
+                var result = object.getAttribute(parts[0]); //incase of of a get object, return the GUIDs (but sometimes getAttribute gives the object...)
+                if (!result) {
+                    return "";
+                }
+                if (result.guid) {
+                    return result.guid;
+                }
+                if (/\d+/.test(result)) {
+                    return result;
+                }
+            }
+            throw "GridCommons.getObjectAttr: Failed to retrieve attribute '" + attr + "'";
 
         },
         _insertGoogleAnalytics: function () {
@@ -85,8 +155,8 @@ define([
         _addPage: function () {
             ga('send', {
                 'hitType': 'pageview',
-                'page': this.trackUrl,
-                'title': this.pageTitle
+                'page': this._replaceTags(this.trackUrl),
+                'title': this._replaceTags(this.pageTitle)
             });
         },
 

--- a/src/GoogleAnalytics/widget/PageTracker.js
+++ b/src/GoogleAnalytics/widget/PageTracker.js
@@ -71,11 +71,15 @@ define([
                 m.parentNode.insertBefore(a, m);
             }
         },
+        _replaceTags: function(s) {
 
+        },
         _insertGoogleAnalytics: function () {
             this._addGoogle(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
 
-            ga('create', this.uaTrackCode, 'auto');
+            if (typeof window.mxGoogleAnalytics === "undefined") {
+                ga('create', this.uaTrackCode, 'auto');
+            }
         },
 
         _addPage: function () {

--- a/src/package.xml
+++ b/src/package.xml
@@ -2,6 +2,7 @@
 <package xmlns="http://www.mendix.com/package/1.0/">
 	<clientModule name="GoogleAnalytics" version="2.0.0" xmlns="http://www.mendix.com/clientModule/1.0/">
 		<widgetFiles>
+            <widgetFile path="GoogleAnalytics/MasterPageTracker.xml"/>
 			<widgetFile path="GoogleAnalytics/PageTracker.xml"/>
 			<widgetFile path="GoogleAnalytics/WebmasterTools.xml"/>
 			<widgetFile path="GoogleAnalytics/EventTracker.xml"/>


### PR DESCRIPTION
- MasterPageTracker can be used in a master layout which is a very convenient way to start with GoogleAnalytics. It will track all pages and give the path and title based on the Mendix form.
- Possibility to have the tracker id (UA-XXX-XX) in a single place even if PageTrackers are used.
- Tracker will only be created one time.
