### PR TITLE
Added a possibility to include a prefix/namespace in MasterPageTracker

### DIFF
--- a/src/GoogleAnalytics/MasterPageTracker.xml
+++ b/src/GoogleAnalytics/MasterPageTracker.xml
@@ -24,6 +24,11 @@
             <category>Behavior</category>
             <description>The UA-XXX-XX code for including google analytics code inside the webpage.</description>
         </property>
+        <property key="prefix" type="string" defaultValue="" required="false">
+            <caption>URL prefix</caption>
+            <category>Behavior</category>
+            <description>The prefix that you want to be displayed in the Google Analytics. It is especially useful if you are using this widget in different apps while using the same tracked code (UA-XX-XXX)</description>
+        </property>
         <property key="trackIt" type="boolean" defaultValue="true">
             <caption>Active</caption>
             <category>Behavior</category>

--- a/src/GoogleAnalytics/widget/MasterPageTracker.js
+++ b/src/GoogleAnalytics/widget/MasterPageTracker.js
@@ -92,6 +92,9 @@ define([
             var pageExtension = '.page.xml';
             var oriPath = this.mxform.path;
             var path = oriPath.substr(0, oriPath.length - pageExtension.length);
+            if (typeof this.prefix !== "undefined" && this.prefix !== "") {
+                path = this.prefix + "/" + path;
+            }
             ga('send', {
                 'hitType': 'pageview',
                 'page': path,


### PR DESCRIPTION
Added a possibility to include prefix as a kind of namespace for MasterPageTracker. Especially useful if you want to track several apps in the same place and still have a nice way to differentiate the urls.
